### PR TITLE
로그인 버튼 여러번 누르는 것 방지 & DataStore 관련 코드 변경

### DIFF
--- a/app/src/main/java/com/example/android_repo_05/base/CustomApplication.kt
+++ b/app/src/main/java/com/example/android_repo_05/base/CustomApplication.kt
@@ -2,45 +2,17 @@ package com.example.android_repo_05.base
 
 import android.app.Application
 import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.emptyPreferences
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
-import java.io.IOException
 
 class CustomApplication : Application() {
     companion object {
-        lateinit var instance: Context
-
-        val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "accessToken")
-        private val tokenPreferenceKey = stringPreferencesKey("ACCESSTOKEN")
-        //TODO : DataStore 관련 어떻게 할지 결정하기 (application?, repository?)
-        lateinit var accessTokenFlow: Flow<String>
-        suspend fun setAccessToken(context: Context = instance, accessToken: String) {
-            context.dataStore.edit { preferences ->
-                preferences[tokenPreferenceKey] = accessToken
-            }
-        }
+        lateinit var instance: CustomApplication
+            private set
     }
+
+    val context: Context get() = applicationContext
 
     override fun onCreate() {
         super.onCreate()
-        instance = applicationContext
-        accessTokenFlow = instance.dataStore.data
-            .catch { exception ->
-                if (exception is IOException) emit(emptyPreferences())
-                else throw exception
-            }
-            .map { preferences ->
-                var accessToken = preferences[tokenPreferenceKey] ?: ""
-                accessToken
-            }.flowOn(Dispatchers.IO)
+        instance = this
     }
 }

--- a/app/src/main/java/com/example/android_repo_05/data/datastore/DataStoreExt.kt
+++ b/app/src/main/java/com/example/android_repo_05/data/datastore/DataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.example.android_repo_05.data.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "accessToken")

--- a/app/src/main/java/com/example/android_repo_05/data/models/TokenModel.kt
+++ b/app/src/main/java/com/example/android_repo_05/data/models/TokenModel.kt
@@ -4,9 +4,9 @@ import com.google.gson.annotations.SerializedName
 
 data class TokenModel(
     @SerializedName("access_token")
-    val accessToken: String,
+    val accessToken: String?,
     @SerializedName("scope")
-    val scope: String,
+    val scope: String?,
     @SerializedName("token_type")
-    val tokenType: String
+    val tokenType: String?
 )

--- a/app/src/main/java/com/example/android_repo_05/data/repositories/TokenRepository.kt
+++ b/app/src/main/java/com/example/android_repo_05/data/repositories/TokenRepository.kt
@@ -1,8 +1,12 @@
 package com.example.android_repo_05.data.repositories
 
-import android.util.Log
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.android_repo_05.base.CustomApplication
+import com.example.android_repo_05.data.datastore.dataStore
 import com.example.android_repo_05.data.models.ResponseState
 import com.example.android_repo_05.data.models.TokenModel
+import com.example.android_repo_05.others.Constants
 import com.example.android_repo_05.retrofit.GithubApiInstance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -28,12 +32,18 @@ class TokenRepository {
     private fun handleTokenResponse(response: Response<TokenModel>): ResponseState<TokenModel> {
         if (response.isSuccessful) {
             response.body()?.let { result ->
-                if(result.accessToken.isNullOrBlank()) {
+                if (result.accessToken.isNullOrBlank()) {
                     return ResponseState.Error("AccessToken 획득 실패")
                 }
                 return ResponseState.Success(result)
             }
         }
         return ResponseState.Error(response.message())
+    }
+
+    suspend fun setAccessToken(accessToken: String) {
+        CustomApplication.instance.context.dataStore.edit { preferences ->
+            preferences[stringPreferencesKey(Constants.prefKey)] = accessToken
+        }
     }
 }

--- a/app/src/main/java/com/example/android_repo_05/data/repositories/TokenRepository.kt
+++ b/app/src/main/java/com/example/android_repo_05/data/repositories/TokenRepository.kt
@@ -1,5 +1,6 @@
 package com.example.android_repo_05.data.repositories
 
+import android.util.Log
 import com.example.android_repo_05.data.models.ResponseState
 import com.example.android_repo_05.data.models.TokenModel
 import com.example.android_repo_05.retrofit.GithubApiInstance
@@ -27,6 +28,9 @@ class TokenRepository {
     private fun handleTokenResponse(response: Response<TokenModel>): ResponseState<TokenModel> {
         if (response.isSuccessful) {
             response.body()?.let { result ->
+                if(result.accessToken.isNullOrBlank()) {
+                    return ResponseState.Error("AccessToken 획득 실패")
+                }
                 return ResponseState.Success(result)
             }
         }

--- a/app/src/main/java/com/example/android_repo_05/others/Constants.kt
+++ b/app/src/main/java/com/example/android_repo_05/others/Constants.kt
@@ -9,4 +9,5 @@ object Constants {
     const val SEARCH_PAGE_SIZE = 10
     const val ISSUE_PAGE_SIZE = 10
 
+    const val prefKey = "ACCESS_TOKEN"
 }

--- a/app/src/main/java/com/example/android_repo_05/retrofit/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/android_repo_05/retrofit/AuthInterceptor.kt
@@ -1,17 +1,34 @@
 package com.example.android_repo_05.retrofit
 
-import com.example.android_repo_05.base.CustomApplication.Companion.accessTokenFlow
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.android_repo_05.base.CustomApplication
+import com.example.android_repo_05.data.datastore.dataStore
+import com.example.android_repo_05.others.Constants
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.io.IOException
 
 class AuthInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = runBlocking(Dispatchers.IO) { accessTokenFlow.first() }
-        val req = chain.request().newBuilder().addHeader("Accept", "application/vnd.github+json")
-            .addHeader("Authorization", "token $accessToken").build()
+        val accessToken = runBlocking(Dispatchers.IO) {
+            CustomApplication.instance.context.dataStore.data
+                .catch { exception ->
+                    if (exception is IOException) emit(emptyPreferences()) else throw exception
+                }.map { preferences ->
+                    preferences[stringPreferencesKey(Constants.prefKey)] ?: ""
+                }.flowOn(Dispatchers.IO).first()
+        }
+        val req = chain.request().newBuilder()
+            .addHeader("Accept", "application/vnd.github+json")
+            .addHeader("Authorization", "token $accessToken")
+            .build()
         return chain.proceed(req)
     }
 }

--- a/app/src/main/java/com/example/android_repo_05/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/example/android_repo_05/ui/activities/LoginActivity.kt
@@ -3,15 +3,16 @@ package com.example.android_repo_05.ui.activities
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.example.android_repo_05.R
-import com.example.android_repo_05.data.models.TokenModel
 import com.example.android_repo_05.data.models.ResponseState
+import com.example.android_repo_05.data.models.TokenModel
 import com.example.android_repo_05.databinding.ActivityLoginBinding
 import com.example.android_repo_05.others.Utils
-import com.example.android_repo_05.ui.viewmodels.TokenViewModel
 import com.example.android_repo_05.ui.viewmodels.AppViewModelFactory
+import com.example.android_repo_05.ui.viewmodels.TokenViewModel
 import com.google.android.material.snackbar.Snackbar
 
 class LoginActivity : AppCompatActivity() {
@@ -30,6 +31,7 @@ class LoginActivity : AppCompatActivity() {
 
     private fun initView() {
         binding.btnLogin.setOnClickListener {
+            it.isClickable = false
             getGithubAccessCode()
         }
     }
@@ -74,7 +76,7 @@ class LoginActivity : AppCompatActivity() {
     private fun handleLoginSuccess(state: ResponseState<TokenModel>) {
         binding.cpiLogin.visibility = View.INVISIBLE
         state.data?.let { response ->
-            if (response.tokenType.isNotBlank()) {
+            if (!response.accessToken.isNullOrEmpty()) {
                 tokenViewModel.setAccessTokenToDataStore(response.accessToken)
             }
             startActivity(Intent(this, MainActivity::class.java))
@@ -84,10 +86,12 @@ class LoginActivity : AppCompatActivity() {
 
     private fun handleLoginFailure() {
         binding.cpiLogin.visibility = View.INVISIBLE
-        Snackbar.make(binding.root, R.string.login_login_failure, Snackbar.LENGTH_SHORT).show()
+        binding.btnLogin.isClickable = true
+        Toast.makeText(this, R.string.login_login_failure, Snackbar.LENGTH_SHORT).show()
     }
 
     private fun handleLoginLoading() {
         binding.cpiLogin.visibility = View.VISIBLE
+        binding.btnLogin.isClickable = false
     }
 }

--- a/app/src/main/java/com/example/android_repo_05/ui/viewmodels/TokenViewModel.kt
+++ b/app/src/main/java/com/example/android_repo_05/ui/viewmodels/TokenViewModel.kt
@@ -4,11 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.android_repo_05.base.CustomApplication.Companion.setAccessToken
-import com.example.android_repo_05.data.models.TokenModel
 import com.example.android_repo_05.data.models.ResponseState
+import com.example.android_repo_05.data.models.TokenModel
 import com.example.android_repo_05.data.repositories.TokenRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class TokenViewModel(private val repository: TokenRepository) : ViewModel() {
@@ -20,7 +18,7 @@ class TokenViewModel(private val repository: TokenRepository) : ViewModel() {
         _tokenModel.postValue(repository.getAccessTokenFromRemote(code))
     }
 
-    fun setAccessTokenToDataStore(accessToken: String) = viewModelScope.launch(Dispatchers.IO) {
-        setAccessToken(accessToken = accessToken)
+    fun setAccessTokenToDataStore(accessToken: String) = viewModelScope.launch {
+        repository.setAccessToken(accessToken = accessToken)
     }
 }


### PR DESCRIPTION
- 로그인 상태에 따라 로그인 버튼 활성화 & 비활성화
- CustomApplication 코드 정리
- Interceptor 내부에서 dataStore에 저장된 accessToken 불러오도록 변경
- accessToken 저장은 viewModel과 repository를 거치도록 수정