### PR TITLE
[FIX] SearchActivity의 로딩결과 꼬이는 버그 수정

### DIFF
--- a/app/src/main/java/com/example/android_repo_05/adapters/AppBindingAdapter.kt
+++ b/app/src/main/java/com/example/android_repo_05/adapters/AppBindingAdapter.kt
@@ -74,8 +74,8 @@ fun loadBitmapFromUrl(toolbar: MaterialToolbar, url: String?) {
         })
 }
 
-@BindingAdapter("hideOnLoading")
-fun hideOnLoading(view : View, responseState: ResponseState<*>?) {
+@BindingAdapter("showOnSuccess")
+fun showOnSuccess(view : View, responseState: ResponseState<*>?) {
     view.visibility = if (responseState is ResponseState.Success) View.VISIBLE else View.GONE
 }
 

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -42,7 +42,7 @@
                 android:id="@+id/l_profile_success"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:hideOnLoading="@{responseState}">
+                app:showOnSuccess="@{responseState}">
 
                 <androidx.constraintlayout.widget.Guideline
                     android:id="@+id/gl_profile_begin"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -4,10 +4,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <import type="com.example.android_repo_05.ui.activities.SearchType"/>
+        <import type="android.view.View"/>
         <variable
             name="isStartIconEnabled"
             type="Boolean" />
+
+        <variable
+            name="searchState"
+            type="com.example.android_repo_05.ui.activities.SearchType" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -63,7 +68,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
-            android:visibility="gone"
+            android:visibility="@{searchState == SearchType.Result ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/l_tf_search">
 
@@ -79,7 +84,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="24dp"
-            android:visibility="gone"
+            android:visibility="@{searchState == SearchType.NoQuery ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -112,6 +117,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminate="true"
+            android:visibility="@{searchState == SearchType.Loading ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -123,6 +129,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="24dp"
+            android:visibility="@{searchState == SearchType.NoResult ? View.VISIBLE : View.INVISIBLE}"
             android:text="@string/search_no_result"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -51,6 +51,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/bg_search_tf"
                 android:freezesText="true"
+                android:inputType="text"
                 android:hint="@string/search_textField_hint">
 
                 <requestFocus />


### PR DESCRIPTION
Search Activity의 로딩화면, 빈화면을 보여주는 로직이 꼬이는 현상이 있어 이를 수정하고 데이터바인딩을 반영하였습니다.

함께 페어프로그래밍으로 버그를 해결하였습니다.